### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/public/js/upload-handler.js
+++ b/public/js/upload-handler.js
@@ -110,13 +110,25 @@ function updateDropZoneUI(file) {
     // Format file size
     const fileSize = niceBytes(file.size).replace('/s', '');
     
-    fileInfo.innerHTML = `
-        <i class="bi ${fileIcon}"></i>
-        <div class="file-details">
-            <div class="file-name">${file.name}</div>
-            <div class="file-size">${fileSize}</div>
-        </div>
-    `;
+    const fileIconElement = document.createElement('i');
+    fileIconElement.className = `bi ${fileIcon}`;
+    
+    const fileDetailsElement = document.createElement('div');
+    fileDetailsElement.className = 'file-details';
+    
+    const fileNameElement = document.createElement('div');
+    fileNameElement.className = 'file-name';
+    fileNameElement.textContent = file.name;
+    
+    const fileSizeElement = document.createElement('div');
+    fileSizeElement.className = 'file-size';
+    fileSizeElement.textContent = fileSize;
+    
+    fileDetailsElement.appendChild(fileNameElement);
+    fileDetailsElement.appendChild(fileSizeElement);
+    
+    fileInfo.appendChild(fileIconElement);
+    fileInfo.appendChild(fileDetailsElement);
     
     dropZone.appendChild(fileInfo);
     dropZonePrompt.style.display = 'none';


### PR DESCRIPTION
Potential fix for [https://github.com/Elcapitanoe/File-Hasher-V2/security/code-scanning/1](https://github.com/Elcapitanoe/File-Hasher-V2/security/code-scanning/1)

To fix the issue, we need to ensure that any untrusted data (e.g., `file.name` and `file.size`) is properly escaped before being inserted into the DOM. Instead of using `innerHTML`, we can create and append DOM elements programmatically, which avoids the need to parse HTML strings and mitigates the risk of XSS. This approach ensures that the browser treats the data as plain text, even if it contains special characters.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
