### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   lint-and-test:
     runs-on: ubuntu-latest
@@ -51,6 +54,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: lint-and-test
     if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      deployments: write
     
     steps:
     - name: Checkout code
@@ -86,6 +92,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: lint-and-test
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    permissions:
+      contents: read
+      deployments: write
     
     steps:
     - name: Checkout code


### PR DESCRIPTION
Potential fix for [https://github.com/Elcapitanoe/File-Hasher-V2/security/code-scanning/8](https://github.com/Elcapitanoe/File-Hasher-V2/security/code-scanning/8)

To fix the issue, we will add a `permissions` block at the root of the workflow file to define the minimal permissions required for all jobs. Additionally, we will add specific `permissions` blocks for individual jobs if they require elevated permissions. For this workflow:
- The `lint-and-test` job only needs `contents: read` to check out the code.
- The `deploy-preview` and `deploy-production` jobs require `contents: read` and `deployments: write` to deploy to Netlify and manage deployment statuses.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
